### PR TITLE
[BOS-6833] Skip metadata check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          verify_metadata: false
           user: __token__
           verbose: true
           password: ${{ secrets.OKTAGON_PYPI_TOKEN }}


### PR DESCRIPTION
The release workflow was faling validate the `README.md` file. Probabliy under the hood `twine` is complaing something about the markdown, even if I esplicitally add `long_description_content_type='text/markdown'` in the `setup.cfg` config. So I will skip this little check, we don't need it.
 
